### PR TITLE
Fix02/notification

### DIFF
--- a/src/main/java/com/beteam/willu/notification/controller/NotificationController.java
+++ b/src/main/java/com/beteam/willu/notification/controller/NotificationController.java
@@ -4,14 +4,13 @@ import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import com.beteam.willu.common.ApiResponseDto;
@@ -22,14 +21,13 @@ import com.beteam.willu.notification.service.NotificationService;
 
 import lombok.RequiredArgsConstructor;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class NotificationController {
 	private final NotificationService notificationService;
 
 	//현재 로그인한 ID에 대한(본인) 구독으로 EventStream 생성 하도록 함. 후에 수정 여지 있음
 	@GetMapping(value = "/subscribe", produces = "text/event-stream")
-	@ResponseBody
 	public SseEmitter subscribe(@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestHeader(value = "Last-Event-ID", required = false, defaultValue = "") String lastEventId) {
 		return notificationService.subscribe(userDetails.getUser().getId(), lastEventId);
@@ -37,22 +35,24 @@ public class NotificationController {
 
 	//알림 읽음 상태 수정 안읽음 <-> 읽음
 	@PatchMapping("/api/notification/{id}")
-	@ResponseBody
+
 	public ResponseEntity<ApiResponseDto> updateNotification(@PathVariable long id) {
 		notificationService.updateRead(id);
 		return ResponseEntity.ok().body(new ApiResponseDto("읽음 상태 처리 완료", 200));
 	}
 
 	@PostMapping("/api/notifications")
-	@ResponseBody
 	public ResponseEntity<ApiResponseDto> sendJoinNotifcation(@RequestBody NotificationRequestDto requestDto,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		if (requestDto.getNotificationId() != null) {
+			notificationService.updateRead(requestDto.getNotificationId());
+		}
+
 		notificationService.sendRequestNotification(requestDto, userDetails.getUser());
 		return ResponseEntity.ok().body(new ApiResponseDto("알림 전송 완료", 200));
 	}
 
 	@GetMapping("/api/notifications")
-	@ResponseBody
 	public ResponseEntity<List<NotificationResponseDto>> showNotifications(
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		return ResponseEntity.ok(notificationService.getNotificationByUserId(userDetails.getUser().getId()));

--- a/src/main/java/com/beteam/willu/notification/dto/NotificationRequestDto.java
+++ b/src/main/java/com/beteam/willu/notification/dto/NotificationRequestDto.java
@@ -11,4 +11,5 @@ public class NotificationRequestDto {
 	private Long postId;
 	private NotificationType type;
 	private Long receiverId;
+	private Long notificationId;
 }

--- a/src/main/java/com/beteam/willu/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/beteam/willu/notification/dto/NotificationResponseDto.java
@@ -20,7 +20,8 @@ public class NotificationResponseDto {
 	private NotificationType notificationType;
 
 	private String nickname;
-	private Long userId;
+	private Long receiverId;
+	private Long publisherId;
 	private Long postId;
 
 	public NotificationResponseDto(Notification notification) {
@@ -30,7 +31,8 @@ public class NotificationResponseDto {
 		this.isRead = notification.getIsRead();
 		this.notificationType = notification.getNotificationType();
 		this.nickname = notification.getReceiver().getNickname();
-		this.userId = notification.getReceiver().getId();
+		this.receiverId = notification.getReceiver().getId();
+		this.publisherId = notification.getPublisher().getId();
 		this.postId = notification.getPostId();
 
 	}

--- a/src/main/java/com/beteam/willu/notification/service/NotificationService.java
+++ b/src/main/java/com/beteam/willu/notification/service/NotificationService.java
@@ -27,31 +27,32 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Slf4j
 public class NotificationService {
-	private static final Long DEFAULT_TIMEOUT = 60 * 60L * 1000; //테스트를 위해
+	private static final Long DEFAULT_TIMEOUT = 30 * 60L * 1000; //테스트를 위해
 	private final EmitterRepository emitterRepository;
 	private final NotificationRepository notificationRepository;
 	private final PostRepository postRepository;
 	private final UserRepository userRepository;
 
-	//참가 요청 알림 보내기
-	public void sendRequestNotification(NotificationRequestDto requestDto, User user) {
+	//참가 요청 알림 보내기,거절알림 보내기
+	public void sendRequestNotification(NotificationRequestDto requestDto, User loginUser) {
 		Long postId = requestDto.getPostId();
 		Post post = postRepository.findById(postId).orElseThrow();
 		String type = requestDto.getType().getDescription();
 		switch (type) {
 			case "참가 신청" -> {
 				log.info("참가 신청 알림");
-				send(user, post.getUser(), requestDto.getType(),
-					user.getNickname() + " 님이 " + post.getTitle() + " 게시글 참가를 요청했습니다", "참가 요청 알림", postId);
+				send(loginUser, post.getUser(), requestDto.getType(),
+					loginUser.getNickname() + " 님이 " + post.getTitle() + " 게시글 참가를 요청했습니다", "참가 요청 알림", postId);
+
 			}
 			case "참가 거절" -> {
 				log.info("참가 거절 알림");
 				User receiver = userRepository.findById(requestDto.getReceiverId()).orElseThrow();
-				if (!Objects.equals(post.getUser().getId(), user.getId())) {
+				if (!Objects.equals(post.getUser().getId(), loginUser.getId())) {
 					throw new IllegalArgumentException("게시글 작성자가 아닙니다. 알림을 보낼 수 없습니다.");
 				}
-				send(user, receiver, requestDto.getType(),
-					user.getNickname() + " 님이 " + post.getTitle() + " 게시글 참가를 거절했습니다", "요청 거절 알림", postId);
+				send(loginUser, receiver, requestDto.getType(),
+					loginUser.getNickname() + " 님이 " + post.getTitle() + " 게시글 참가를 거절했습니다", "요청 거절 알림", postId);
 			}
 		}
 
@@ -110,21 +111,33 @@ public class NotificationService {
 			log.info("eventCache 저장 key: " + eventId + " notification: " + notification);
 			emitterRepository.saveEventCache(eventId, notification);
 		}
-
 	}
 
 	private Notification createNotification(User publisher, User receiver, NotificationType notificationType,
-		String content,
-		String title, Long postId) {
-		return Notification.builder()
-			.receiver(receiver)
-			.publisher(publisher)
-			.notificationType(notificationType)
-			.content(content)
-			.title(title)
-			.isRead(false)
-			.postId(postId)
-			.build();
+		String content, String title, Long postId) {
+		Notification notification;
+		if (Objects.equals(notificationType, NotificationType.JOIN_REQUEST)) {
+			notification = Notification.builder()
+				.receiver(receiver)
+				.publisher(publisher)
+				.notificationType(notificationType)
+				.content(content)
+				.title(title)
+				.postId(postId)
+				.isRead(false)
+				.build();
+		} else {
+			notification = Notification.builder()
+				.receiver(receiver)
+				.publisher(publisher)
+				.notificationType(notificationType)
+				.content(content)
+				.title(title)
+				.postId(postId)
+				.isRead(true)
+				.build();
+		}
+		return notification;
 	}
 
 	private boolean hasLostData(String lastEventId) {

--- a/src/main/java/com/beteam/willu/stomp/controller/ChatRoomController.java
+++ b/src/main/java/com/beteam/willu/stomp/controller/ChatRoomController.java
@@ -1,97 +1,112 @@
 package com.beteam.willu.stomp.controller;
 
-import com.beteam.willu.common.ApiResponseDto;
-import com.beteam.willu.common.security.UserDetailsImpl;
-import com.beteam.willu.stomp.dto.*;
-import com.beteam.willu.stomp.service.ChatRoomService;
-import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.beteam.willu.common.ApiResponseDto;
+import com.beteam.willu.common.security.UserDetailsImpl;
+import com.beteam.willu.notification.service.NotificationService;
+import com.beteam.willu.stomp.dto.ChatRoomNameResponseDto;
+import com.beteam.willu.stomp.dto.ChatRoomsResponseDto;
+import com.beteam.willu.stomp.dto.ChatSaveRequestDto;
+import com.beteam.willu.stomp.dto.ChatroomJoinRequestDto;
+import com.beteam.willu.stomp.dto.ChatsResponseDto;
+import com.beteam.willu.stomp.service.ChatRoomService;
+
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api")
 public class ChatRoomController {
 
-    private final ChatRoomService chatRoomService;
+	private final ChatRoomService chatRoomService;
+	private final NotificationService notificationService;
 
-    // 게시물이 생성되었을때 채팅룸 생성 (확인 완료)
-    @PostMapping("/chat/posts/{id}/creatRoom")
-    public void createRoom(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        chatRoomService.createRoom(id, userDetails);
-    }
+	// 게시물이 생성되었을때 채팅룸 생성 (확인 완료)
+	@PostMapping("/chat/posts/{id}/creatRoom")
+	public void createRoom(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		chatRoomService.createRoom(id, userDetails);
+	}
 
-    // 사용자가 속한 채팅방(모두) 불러오기 (확인 완료) (프론트 적용 완료)
-    // 채팅방 비활성화 (채팅방 저장 테이터중 활성화 필드가 true인 값만 가져온다.)
-    @GetMapping("/chat/users/{id}")
-    public ChatRoomsResponseDto getRooms(@PathVariable Long id) {
-        return chatRoomService.getRooms(id);
-    }
+	// 사용자가 속한 채팅방(모두) 불러오기 (확인 완료) (프론트 적용 완료)
+	// 채팅방 비활성화 (채팅방 저장 테이터중 활성화 필드가 true인 값만 가져온다.)
+	@GetMapping("/chat/users/{id}")
+	public ChatRoomsResponseDto getRooms(@PathVariable Long id) {
+		return chatRoomService.getRooms(id);
+	}
 
-    // 쿠키에 저장된 사용자 이름으로 사용자 id 가져오기 (확인 완료) (프론트 적용 완료)
-    // 채팅방에 유저 id 엔티티가 없음 (수정 가능성 있음)
-    @GetMapping("/chat/getUsers/{id}")
-    public Long getUser(@PathVariable String id) {
-        return chatRoomService.getUser(id);
-    }
+	// 쿠키에 저장된 사용자 이름으로 사용자 id 가져오기 (확인 완료) (프론트 적용 완료)
+	// 채팅방에 유저 id 엔티티가 없음 (수정 가능성 있음)
+	@GetMapping("/chat/getUsers/{id}")
+	public Long getUser(@PathVariable String id) {
+		return chatRoomService.getUser(id);
+	}
 
-    // 특정 채팅룸 불러오기 (채팅방의 활성화 확인)
-    @GetMapping("/chat/chatRooms/{id}")
-    public ChatRoomNameResponseDto getRoom(@PathVariable Long id,
-                                           @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return chatRoomService.getRoom(id, userDetails);
-    }
+	// 특정 채팅룸 불러오기 (채팅방의 활성화 확인)
+	@GetMapping("/chat/chatRooms/{id}")
+	public ChatRoomNameResponseDto getRoom(@PathVariable Long id,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		return chatRoomService.getRoom(id, userDetails);
+	}
 
-    // 생성된 채팅 저장 (확인 완료) (프론트 적용 완료)
-    @PostMapping("/chat/chatRooms")
-    public void createRooms(@RequestBody ChatSaveRequestDto chatSaveRequestDto) {
-        chatRoomService.createRooms(chatSaveRequestDto);
-    }
+	// 생성된 채팅 저장 (확인 완료) (프론트 적용 완료)
+	@PostMapping("/chat/chatRooms")
+	public void createRooms(@RequestBody ChatSaveRequestDto chatSaveRequestDto) {
+		chatRoomService.createRooms(chatSaveRequestDto);
+	}
 
-    // 특정 채팅방 채팅 조회 (확인 완료) (프론트 적용 완료)
-    @GetMapping("/chat/chatRoom/{id}")
-    public ChatsResponseDto getChat(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        return chatRoomService.getChat(id, userDetails);
-    }
+	// 특정 채팅방 채팅 조회 (확인 완료) (프론트 적용 완료)
+	@GetMapping("/chat/chatRoom/{id}")
+	public ChatsResponseDto getChat(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		return chatRoomService.getChat(id, userDetails);
+	}
 
-    //(할것)
-    // 로그인한 유저의 채팅방 추가(사용할 일 없을지도..!)
-    @PostMapping("chat/join/{postId}/{chatRoomId}")
-    public ResponseEntity<ApiResponseDto> userJoin(@PathVariable long postId, @PathVariable long chatRoomId,
-                                                   @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        chatRoomService.userJoin(postId, chatRoomId, userDetails);
-        return ResponseEntity.ok().body(new ApiResponseDto("사용자 채팅방 추가 성공", 200));
-    }
+	//(할것)
+	// 로그인한 유저의 채팅방 추가(사용할 일 없을지도..!)
+	@PostMapping("chat/join/{postId}/{chatRoomId}")
+	public ResponseEntity<ApiResponseDto> userJoin(@PathVariable long postId, @PathVariable long chatRoomId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		chatRoomService.userJoin(postId, chatRoomId, userDetails);
+		return ResponseEntity.ok().body(new ApiResponseDto("사용자 채팅방 추가 성공", 200));
+	}
 
-    //채팅방 참가
-    @PostMapping("/chatRoom/join")
-    public void joinUserChatRoom(@RequestBody ChatroomJoinRequestDto requestDto,
-                                 @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        chatRoomService.joinUserChatRoom(requestDto, userDetails.getUser());
-    }
+	//채팅방 참가
+	@PostMapping("/chatRoom/join")
+	public void joinUserChatRoom(@RequestBody ChatroomJoinRequestDto requestDto,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		notificationService.updateRead(requestDto.getNotificationId());
+		chatRoomService.joinUserChatRoom(requestDto, userDetails.getUser());
+	}
 
-    // 사용자 채팅방에서 다른사용자 추방 (ADMIN 용) (프론트 적용 완료)
-    // 특청 사용자의 id를 이용해 테이블에서 유저 삭제
-    // 강퇴된 유저가 다시 채팅방에 신청 했을 때 생각하기 (미구현)
-    @DeleteMapping("/chat/users/{userId}/chatRoom/{chatId}/kickout")
-    public void kickoutUser(@PathVariable(name = "userId") Long userId, @PathVariable Long chatId,
-                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        chatRoomService.kickoutUser(userId, chatId, userDetails);
-    }
+	// 사용자 채팅방에서 다른사용자 추방 (ADMIN 용) (프론트 적용 완료)
+	// 특청 사용자의 id를 이용해 테이블에서 유저 삭제
+	// 강퇴된 유저가 다시 채팅방에 신청 했을 때 생각하기 (미구현)
+	@DeleteMapping("/chat/users/{userId}/chatRoom/{chatId}/kickout")
+	public void kickoutUser(@PathVariable(name = "userId") Long userId, @PathVariable Long chatId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		chatRoomService.kickoutUser(userId, chatId, userDetails);
+	}
 
-    // 사용자 채팅방 나가기 (USER 용) -> (인원이 있을때 방장이 나갔다 / 채팅방에 사람이 아예 없을때)
-    // (프론트 적용 완료)
-    @DeleteMapping("/chat/chatRoom/{id}/out")
-    public void outUser(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
-        chatRoomService.outUser(id, userDetails);
-    }
+	// 사용자 채팅방 나가기 (USER 용) -> (인원이 있을때 방장이 나갔다 / 채팅방에 사람이 아예 없을때)
+	// (프론트 적용 완료)
+	@DeleteMapping("/chat/chatRoom/{id}/out")
+	public void outUser(@PathVariable Long id, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+		chatRoomService.outUser(id, userDetails);
+	}
 
-    // 채팅방 사용자들 조회 (프론트 적용 완료)
-    // 채팅방 id를 사용해서 조회
-    @GetMapping("/chat/chatRooms/{id}/users")
-    public ChatRoomsResponseDto getChatRoomUsers(@PathVariable Long id) {
-        return chatRoomService.getChatRoomUsers(id);
-    }
+	// 채팅방 사용자들 조회 (프론트 적용 완료)
+	// 채팅방 id를 사용해서 조회
+	@GetMapping("/chat/chatRooms/{id}/users")
+	public ChatRoomsResponseDto getChatRoomUsers(@PathVariable Long id) {
+		return chatRoomService.getChatRoomUsers(id);
+	}
 
 }

--- a/src/main/java/com/beteam/willu/stomp/dto/ChatroomJoinRequestDto.java
+++ b/src/main/java/com/beteam/willu/stomp/dto/ChatroomJoinRequestDto.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 public class ChatroomJoinRequestDto {
 	private Long postId;
 	private Long userId;
+	private Long notificationId;
 
 }

--- a/src/main/java/com/beteam/willu/stomp/entity/ChatRoom.java
+++ b/src/main/java/com/beteam/willu/stomp/entity/ChatRoom.java
@@ -1,13 +1,27 @@
 package com.beteam.willu.stomp.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import com.beteam.willu.common.Timestamped;
 import com.beteam.willu.post.entity.Post;
 import com.beteam.willu.review.entity.Review;
-import jakarta.persistence.*;
-import lombok.*;
 
-import java.util.ArrayList;
-import java.util.List;
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
@@ -16,37 +30,37 @@ import java.util.List;
 @Table(name = "ChatRooms")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ChatRoom extends Timestamped {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "chatRoom_id")
-    private Long id;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "chatRoom_id")
+	private Long id;
 
-    @OneToOne
-    @JoinColumn(name = "post_id")
-    private Post post;
+	@OneToOne
+	@JoinColumn(name = "post_id")
+	private Post post;
 
-    // 채팅방 제목
-    @Column(name = "chatTitle")
-    private String chatTitle;
+	// 채팅방 제목
+	@Column(name = "chatTitle")
+	private String chatTitle;
 
-    // 상태
-    @Column(name = "activated")
-    private boolean activated;
+	// 상태
+	@Column(name = "activated")
+	private boolean activated;
 
-    // 게시물 삭제시 해당 채팅방, 채팅메시지, 채팅유저 삭제
-    @OneToMany(mappedBy = "chatRooms", cascade = CascadeType.REMOVE)
-    @Builder.Default
-    private List<UserChatRoom> userChatRoomList = new ArrayList<>();
+	// 게시물 삭제시 해당 채팅방, 채팅메시지, 채팅유저 삭제
+	@OneToMany(mappedBy = "chatRooms", cascade = CascadeType.ALL)
+	@Builder.Default
+	private List<UserChatRoom> userChatRoomList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "chatRooms", cascade = CascadeType.REMOVE)
-    @Builder.Default
-    private List<Chat> chatList = new ArrayList<>();
+	@OneToMany(mappedBy = "chatRooms", cascade = CascadeType.REMOVE)
+	@Builder.Default
+	private List<Chat> chatList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE)
-    @Builder.Default
-    private List<Review> reviewList = new ArrayList<>();
+	@OneToMany(mappedBy = "chatRoom", cascade = CascadeType.REMOVE)
+	@Builder.Default
+	private List<Review> reviewList = new ArrayList<>();
 
-    public void updateActivated(boolean bool) {
-        this.activated = bool;
-    }
+	public void updateActivated(boolean bool) {
+		this.activated = bool;
+	}
 }

--- a/src/main/java/com/beteam/willu/stomp/service/ChatRoomService.java
+++ b/src/main/java/com/beteam/willu/stomp/service/ChatRoomService.java
@@ -175,6 +175,8 @@ public class ChatRoomService {
 
 	@Transactional
 	public void joinUserChatRoom(ChatroomJoinRequestDto requestDto, User loginUser) {
+		//기존 알림 읽음처리
+
 		Long postId = requestDto.getPostId();
 		Post post = findPost(postId);
 		ChatRoom chatRoom = chatRoomRepository.findChatRoomByPost_IdAndActivatedIsTrue(postId)

--- a/src/main/java/com/beteam/willu/stomp/service/ChatRoomService.java
+++ b/src/main/java/com/beteam/willu/stomp/service/ChatRoomService.java
@@ -192,7 +192,7 @@ public class ChatRoomService {
 		} else if (userChatRoomsRepository.existsByUserAndChatRooms(joiner, chatRoom)) {
 			throw new IllegalArgumentException("이미 참여하고 있는 방입니다.");
 		}
-		//TODO 알림 읽음처리
+
 		UserChatRoom guestChatRoom = UserChatRoom.builder().user(joiner).chatRooms(chatRoom).role("GUEST").build();
 		//유저 채팅방 초대
 		userChatRoomsRepository.save(guestChatRoom);
@@ -203,7 +203,7 @@ public class ChatRoomService {
 			.receiver(joiner).publisher(loginUser).content(post.getTitle() + " 게시글에 초대됐습니다.")
 			.postId(postId).build();
 		eventPublisher.publishEvent(approveMessageEvent);
-		//추가 후 인원이 모두 찼는지 확인
+		//추가 후 인원이 모두 찼는지 확인하고 알림 발송
 		if (chatRoom.getUserChatRoomList().size() + 1 >= post.getMaxnum()) {
 			post.setRecruitment(false);
 			//기존 chatRoom에 있는 유저 목록

--- a/src/main/resources/static/js/sidebar.js
+++ b/src/main/resources/static/js/sidebar.js
@@ -58,6 +58,7 @@ eventSource.onmessage = e => {
         const postId = jsonData.postId;
         console.log("ntId: " + ntId);
         console.log("publisherId: " + publisherId);
+        console.log("receiverId: " + receiverId);
         console.log("postId: " + postId);
         showNotification(content, nt, title, ntId);
         addNotificationHTML(content, nt, title, ntId, publisherId, receiverId, postId);
@@ -206,12 +207,13 @@ function read(ntId) {
     });
 }
 
-await function reject(ntId, postId, publisherId) {
+function reject(ntId, postId, publisherId) {
     if (confirm("참가 요청을 거부하시겠습니까?")) {
         console.log("거부했습니다.");
         //거절 알림 전송
         sendReject(ntId, postId, publisherId);
-        read(ntId); //읽기를 거절 알림 보내기에 추가
+        //read(ntId); //읽기를 거절 알림 보내기에 추가
+        removeNotificationHTML(ntId);
         //거절 알림 전송
         //window.location.reload();
     } else {
@@ -219,12 +221,13 @@ await function reject(ntId, postId, publisherId) {
     }
 }
 
-await function approve(ntId, postId, publisherId) {
+function approve(ntId, postId, publisherId) {
     if (confirm("참가 요청을 승인하시겠습니까?")) {
         console.log("승인했습니다.");
 
         sendApprove(ntId, postId, publisherId);
-        read(ntId);
+        // read(ntId);
+        removeNotificationHTML(ntId);
     } else {
         window.focus();
     }
@@ -279,12 +282,13 @@ function removeNotificationHTML(ntId) {
 }
 
 function sendReject(ntId, postId, publisherId) {
-
     const data = {
         "postId": postId,
         "type": "REJECT_REQUEST",
-        "receiverId": publisherId
+        "receiverId": publisherId,
+        "notificationId": ntId
     };
+    console.log(ntId);
     //헤더에 토큰
     $.ajax({
         url: `/api/notifications`, // 요청을 보낼 서버의 URL
@@ -306,8 +310,10 @@ function sendApprove(ntId, postId, publisherId) {
     console.log("승인 전송");
     const data = {
         "postId": postId,
-        "userId": publisherId
+        "userId": publisherId,
+        "notificationId": ntId
     };
+    console.log(ntId);
     //승인 알림 전송
     $.ajax({
         url: `/api/chatRoom/join`, // 요청을 보낼 서버의 URL

--- a/src/main/resources/static/js/sidebar.js
+++ b/src/main/resources/static/js/sidebar.js
@@ -56,17 +56,8 @@ eventSource.onmessage = e => {
         const publisherId = jsonData.publisher.id;
         const receiverId = jsonData.receiver.id;
         const postId = jsonData.postId;
-        console.log("ntId: " + ntId);
-        console.log("publisherId: " + publisherId);
-        console.log("receiverId: " + receiverId);
-        console.log("postId: " + postId);
         showNotification(content, nt, title, ntId);
         addNotificationHTML(content, nt, title, ntId, publisherId, receiverId, postId);
-
-        if (jsonData.notificationType == "APPROVE_REQUEST") {
-            $('.accordion-content').empty();
-            showChatRoom(jsonData.receiver.nickname);
-        }
     }
 }
 eventSource.onerror = error => {
@@ -172,7 +163,7 @@ function goProfile() {
             window.location.href = `/profile/${response}`;
         },
         error: function (xhr, status, error) {
-            alert("불러오기 실패")
+            alert("프로필 페이지 이동 실패")
             console.log(xhr);
         }
     });
@@ -196,10 +187,7 @@ function read(ntId) {
         method: 'PATCH', // 요청 메소드 (GET, POST 등)
         contentType: "application/json",
         success: function (response) {
-            console.log("알림 결과 : ", response);
-            console.log("읽기 처리 완료");
             removeNotificationHTML(ntId);
-
         },
         error: function (xhr, status, error) {
             console.log("읽기 처리 실패");
@@ -250,10 +238,7 @@ function showNotification(content, notificationType, title, ntId) {
     const notification = new Notification(title, notificationOptions);
 
     notification.onclick = function () {
-        // 알림 클릭 시 수행할 동작 설정
         window.focus();
-        //사이드바 열고 알림 목록 보여주기
-
         notification.close();
 
     };
@@ -288,7 +273,6 @@ function sendReject(ntId, postId, publisherId) {
         "receiverId": publisherId,
         "notificationId": ntId
     };
-    console.log(ntId);
     //헤더에 토큰
     $.ajax({
         url: `/api/notifications`, // 요청을 보낼 서버의 URL
@@ -313,7 +297,6 @@ function sendApprove(ntId, postId, publisherId) {
         "userId": publisherId,
         "notificationId": ntId
     };
-    console.log(ntId);
     //승인 알림 전송
     $.ajax({
         url: `/api/chatRoom/join`, // 요청을 보낼 서버의 URL
@@ -321,8 +304,7 @@ function sendApprove(ntId, postId, publisherId) {
         contentType: "application/json",
         data: JSON.stringify(data),
         success: function (response) {
-            alert("전송 완료");
-
+            console.log("승인 알림 전송 성공");
         },
         error: function (xhr, status, error) {
             alert("전송 실패")
@@ -349,10 +331,6 @@ function showMyNotification() {
                     const publisherId = notification.publisherId;
                     const receiverId = notification.receiverId;
                     const postId = notification.postId;
-                    console.log("ntId: " + ntId);
-                    console.log("publisherId: " + publisherId);
-                    console.log("receiverId: " + receiverId);
-                    console.log("postId: " + postId);
                     addNotificationHTML(content, nt, title, ntId, publisherId, receiverId, postId);
                 }
             });

--- a/src/main/resources/static/js/sidebar.js
+++ b/src/main/resources/static/js/sidebar.js
@@ -3,20 +3,18 @@ const token = getAuthorizationCookie();
 $("#logo").click(function () {
     window.location.href = '/';
 });
-// 클릭 이벤트가 발생했을 때 실행할 코드 작성
 
 
 if (token !== null) {
     const payloads = JSON.parse(atob(token.split(".")[1]));
     const userName = payloads.sub;
-    checkLoginStatus();
     console.log(token);
     console.log(userName);
     getChatRooms(userName);
 }
 
 checkLoginStatus(token);
-//채팅방 조회
+
 
 $(".accordion-header").click(function () {
     $(this).toggleClass("active");
@@ -39,7 +37,6 @@ let ntId;
 
 eventSource.onopen = e => {
     console.log("연결 완료");
-    console.log(e);
 };
 
 eventSource.onmessage = e => {
@@ -57,12 +54,13 @@ eventSource.onmessage = e => {
 
     if (nt !== "MAKE_CONNECTION") {
         const publisherId = jsonData.publisher.id;
+        const receiverId = jsonData.receiver.id;
         const postId = jsonData.postId;
         console.log("ntId: " + ntId);
         console.log("publisherId: " + publisherId);
         console.log("postId: " + postId);
         showNotification(content, nt, title, ntId);
-        addNotificationHTML(content, nt, title, ntId, publisherId, postId);
+        addNotificationHTML(content, nt, title, ntId, publisherId, receiverId, postId);
 
         if (jsonData.notificationType == "APPROVE_REQUEST") {
             $('.accordion-content').empty();
@@ -77,7 +75,6 @@ eventSource.onerror = error => {
 
 //알림 허용 체크
 notifyMe();
-
 
 function getChatRooms(userName) {
     $.ajax({
@@ -138,46 +135,6 @@ function checkLoginStatus(authorizationToken) {
         loginBtnContainer.style.display = 'block';
     }
 }
-
-
-// function openSidebar() {
-//     var sidebar = document.getElementById("sidebar");
-//     var content = document.getElementById("content");
-//     var openBtn = document.getElementById("openBtn");
-//     var closeBtn = document.getElementById("closeBtn");
-//
-//     if (sidebar.style.width === "250px") {
-//         sidebar.style.width = "0";
-//         content.style.marginLeft = "0";
-//         closeBtn.style.display = "none";
-//         openBtn.style.display = "inline-block";
-//     } else {
-//         sidebar.style.width = "250px";
-//         content.style.marginLeft = "260px";
-//         closeBtn.style.display = "inline-block";
-//         openBtn.style.display = "none";
-//     }
-// }
-
-function openSidebar() {
-    let sidebar = document.getElementById("sidebar");
-    let content = document.getElementById("content");
-    let openBtn = document.getElementById("openBtn");
-    let closeBtn = document.getElementById("closeBtn");
-
-    if (sidebar.style.width === "250px") {
-        sidebar.style.width = "0";
-        content.style.marginLeft = "0";
-        closeBtn.style.display = "none";
-        openBtn.style.display = "inline-block";
-    } else {
-        sidebar.style.width = "250px";
-        content.style.marginLeft = "260px";
-        closeBtn.style.display = "inline-block";
-        openBtn.style.display = "none";
-    }
-}
-
 
 function logout() {
     //로그아웃 api 호출하고 로그인 페이지로
@@ -240,7 +197,6 @@ function read(ntId) {
         success: function (response) {
             console.log("알림 결과 : ", response);
             console.log("읽기 처리 완료");
-            //TODO 알림이 포함된 HTML 지우기
             removeNotificationHTML(ntId);
 
         },
@@ -250,10 +206,10 @@ function read(ntId) {
     });
 }
 
-function reject(ntId, postId, publisherId) {
+await function reject(ntId, postId, publisherId) {
     if (confirm("참가 요청을 거부하시겠습니까?")) {
         console.log("거부했습니다.");
-
+        //거절 알림 전송
         sendReject(ntId, postId, publisherId);
         read(ntId); //읽기를 거절 알림 보내기에 추가
         //거절 알림 전송
@@ -263,7 +219,7 @@ function reject(ntId, postId, publisherId) {
     }
 }
 
-function approve(ntId, postId, publisherId) {
+await function approve(ntId, postId, publisherId) {
     if (confirm("참가 요청을 승인하시겠습니까?")) {
         console.log("승인했습니다.");
 
@@ -300,7 +256,7 @@ function showNotification(content, notificationType, title, ntId) {
     };
 }
 
-function addNotificationHTML(content, nt, title, ntId, publisherId, postId) {
+function addNotificationHTML(content, nt, title, ntId, publisherId, receiverId, postId) {
     let newElement =
         `<div class="unread-notification-${ntId}">
                     <h4>${title}</h4>
@@ -311,7 +267,7 @@ function addNotificationHTML(content, nt, title, ntId, publisherId, postId) {
         newElement += `<input type="button" class="btn btn-primary" onclick="approve(${ntId},${postId},${publisherId})" value="승인"  style="background-color:#1746A2">
                                 <input type="button" class="btn btn-primary" onclick="reject(${ntId},${postId},${publisherId})" value="거부" style="background-color:#1746A2">`
     } else {
-        newElement += `<input type="button" class="btn btn-primary" onclick="read(${ntId})" value="닫기" style="background-color:#1746A2">`;
+        newElement += `<input type="button" class="btn btn-primary" onclick="removeNotificationHTML(${ntId})" value="닫기" style="background-color:#1746A2">`;
     }
     newElement += `</div>`;
     eventList.append(newElement);
@@ -340,7 +296,7 @@ function sendReject(ntId, postId, publisherId) {
 
         },
         error: function (xhr, status, error) {
-            alert("저장 실패")
+            alert("전송 실패")
             console.log(xhr);
         }
     });
@@ -363,7 +319,7 @@ function sendApprove(ntId, postId, publisherId) {
 
         },
         error: function (xhr, status, error) {
-            alert("저장 실패")
+            alert("전송 실패")
             console.log(xhr);
         }
     });
@@ -384,51 +340,18 @@ function showMyNotification() {
                 // e.lastEventId = ntId;
 
                 if (nt !== "MAKE_CONNECTION") {
-                    const publisherId = notification.userId;
+                    const publisherId = notification.publisherId;
+                    const receiverId = notification.receiverId;
                     const postId = notification.postId;
                     console.log("ntId: " + ntId);
                     console.log("publisherId: " + publisherId);
+                    console.log("receiverId: " + receiverId);
                     console.log("postId: " + postId);
-                    addNotificationHTML(content, nt, title, ntId, publisherId, postId);
+                    addNotificationHTML(content, nt, title, ntId, publisherId, receiverId, postId);
                 }
             });
         },
         error: function (xhr, status, error) {
-            console.log(xhr);
-        }
-    });
-}
-
-function showChatRoom(userName) {
-    $.ajax({
-        url: `/api/chat/getUsers/${userName}`, // 쿠키에 저장된 사용자의 이름으로 사용자 id 가져오기
-        method: 'GET', // 요청 메소드 (GET, POST 등)
-        success: function (response) {
-
-            // response 사용자의 id
-            $.ajax({
-                url: `/api/chat/users/${response}`, // 가져온 사용자의 id로 사용자가 속한 채팅방들 조회
-                method: 'GET', // 요청 메소드 (GET, POST 등)
-                success: function (response) {
-
-                    if (response.chatRoomList.length == 0) {
-                        // 해당 사용자가 속한 채팅방이 없다면
-                    }
-
-                    // 해당 사용자가 속한 채팅방이 있다면
-                    for (var i = 0; i < response.chatRoomList.length; i++) {
-                        $(`<div id="userChatRoom-${response.chatRoomList[i].id}" class="userChatRoom" onclick="chatRoom(${response.chatRoomList[i].id})">${response.chatRoomList[i].chatName}</div>`).appendTo(`.accordion-content`);
-                    }
-
-                },
-                error: function (xhr, status, error) {
-                    alert("불러오기 실패")
-                    console.log(xhr);
-                }
-            });
-        },
-        error: function (xhr, status, error) {
-            alert("불러오기 실패")
             console.log(xhr);
         }
     });

--- a/src/main/resources/templates/detailPost.html
+++ b/src/main/resources/templates/detailPost.html
@@ -175,10 +175,6 @@
 
     function checkWriterAndShowButtons(loginUserName, postUserName, status) {
 
-        /*        let join = document.getElementById('join');
-                let edit = document.querySelector('.login-btn-container');
-                let delete = document.querySelector('.login-btn-container');*/
-
         if (loginUserName === postUserName) {
             $("#join").css("display", "none");
             $("#edit").css("display", "");
@@ -197,8 +193,6 @@
     }
 
     function makeDateFormat(dateTimeString) {
-
-
         // Date 객체로 변환
         let dateTime = new Date(dateTimeString);
 


### PR DESCRIPTION
클라이언트에서 sse연결 시 알림에 대해 전송하는 api 최소화

- 알림 기능
    
    참가 요청 알림 (상호작용 O)
    
    - 승인 버튼 → 신청자에게 승인 알림
    - 거절 버튼 → 신청자에게 거절 알림
    
    승인 알림:  단순 알림
    
    거절 알림: 단순 알림
    
    모집 완료 알림 - 단순 알림
    
    ---
    

### 해결방법 1

1. 클라이언트에서 읽음 처리 제거
2. ~~상호작용 없는 알림 생성 시 읽음 확인 필드의 값을 true로 생성~~
3. ~~기존에 읽지 않은 알림 목록 조회~~
    
    ~~→ 읽지 않은 `참가 요청 알림`만 조회된다.~~
    
    ~~→`참가 요청 알림`에 대해서는 어차피 상호작용이 일어나기 때문에 상호작용 시 읽음 처리를 백 서비스에서 처리한다.~~
    

⇒이렇게 함으로써 매 알림에 대한 확인 api가 발생하는 것을 막고 꼭 필요한 알림은 계속 조회가 되도록 수정하는 방법을 생각해봤습니다.